### PR TITLE
Feature: add profile info into platform params

### DIFF
--- a/lib/kamigo/event_parsers/line_event_parser.rb
+++ b/lib/kamigo/event_parsers/line_event_parser.rb
@@ -13,9 +13,11 @@ module Kamigo
 
       def parse(event)
         payload = JSON.parse(event.to_json, symbolize_names: true)[:src]
+        response = client.get_profile(payload[:source][:userId])
         line_event = Kamigo::Events::LineEvent.new
         line_event.payload = payload
         line_event.reply_token = event['replyToken']
+        line_event.source_profile = JSON.parse(response.body)
         line_event.source_type = payload.dig(:source, :type)
         line_event.source_group_id = payload.dig(:source, :groupId) || payload.dig(:source, :roomId) || payload.dig(:source, :userId)
         line_event.source_user_id = payload.dig(:source, :userId) || payload.dig(:source, :groupId) || payload.dig(:source, :roomId)

--- a/lib/kamigo/event_parsers/line_event_parser.rb
+++ b/lib/kamigo/event_parsers/line_event_parser.rb
@@ -17,7 +17,7 @@ module Kamigo
         line_event = Kamigo::Events::LineEvent.new
         line_event.payload = payload
         line_event.reply_token = event['replyToken']
-        line_event.source_profile = JSON.parse(response.body)
+        line_event.profile = JSON.parse(response.body)
         line_event.source_type = payload.dig(:source, :type)
         line_event.source_group_id = payload.dig(:source, :groupId) || payload.dig(:source, :roomId) || payload.dig(:source, :userId)
         line_event.source_user_id = payload.dig(:source, :userId) || payload.dig(:source, :groupId) || payload.dig(:source, :roomId)

--- a/lib/kamigo/events/basic_event.rb
+++ b/lib/kamigo/events/basic_event.rb
@@ -7,6 +7,7 @@ module Kamigo
       attr_accessor :source_type
       attr_accessor :source_group_id
       attr_accessor :source_user_id
+      attr_accessor :source_profile
       attr_accessor :payload
 
       def platform_params
@@ -14,7 +15,8 @@ module Kamigo
           platform_type: platform_type,
           source_type: source_type,
           source_group_id: source_group_id,
-          source_user_id: source_user_id
+          source_user_id: source_user_id,
+          profile: source_profile
         }
       end
     end

--- a/lib/kamigo/events/basic_event.rb
+++ b/lib/kamigo/events/basic_event.rb
@@ -7,7 +7,7 @@ module Kamigo
       attr_accessor :source_type
       attr_accessor :source_group_id
       attr_accessor :source_user_id
-      attr_accessor :source_profile
+      attr_accessor :profile
       attr_accessor :payload
 
       def platform_params
@@ -16,7 +16,7 @@ module Kamigo
           source_type: source_type,
           source_group_id: source_group_id,
           source_user_id: source_user_id,
-          profile: source_profile
+          profile: profile
         }
       end
     end


### PR DESCRIPTION
**Description**
- 現況：Kamigo 發送 request 給第三方 app 的 params 沒有 user profile，當 user 單純傳送訊息，第三方 app 在此階段有認證需求，則無法獲取足夠的 user 資訊來 create user（僅能取得 userId）。
- 修改期望：platform params 應包含 user profile 資訊，以利使用 Kamigo 套件的開發者可以取得 user 完整資訊。

**Modify**
- `platform_params` 新增 profile 資訊。
- line event parser 新增從 `Line::Bot::Client` 取得 source profile。

**Params**
- Kamigo 套件修改後的 request params log 截圖
![螢幕快照 2020-12-05 17 04 07](https://user-images.githubusercontent.com/49583246/101238779-6bf91f80-371d-11eb-9fb8-6fd39530dc98.png)

- 使用套件的 app 接收到的新 request params log 截圖
![螢幕快照 2020-12-05 17 08 04](https://user-images.githubusercontent.com/49583246/101238785-76b3b480-371d-11eb-8b9b-3dc689b4dd5f.png)